### PR TITLE
Add layout wrapper to contact and services pages

### DIFF
--- a/src/pages/contact.astro
+++ b/src/pages/contact.astro
@@ -1,0 +1,18 @@
+---
+import Layout from '../layouts/Layout.astro';
+import Navigation from '../components/Navigation.astro';
+import Header from '../components/Header.astro';
+import Footer from '../components/Footer.astro';
+---
+
+<Layout title="Contact | No Clocks">
+  <Navigation activeLink="/contact" />
+  <Header />
+  <main class="site-main">
+    <section class="container">
+      <h2>Contact Us</h2>
+      <p>This page is under construction. Reach out to us anytime with your questions.</p>
+    </section>
+  </main>
+  <Footer />
+</Layout>

--- a/src/pages/services.astro
+++ b/src/pages/services.astro
@@ -1,0 +1,18 @@
+---
+import Layout from '../layouts/Layout.astro';
+import Navigation from '../components/Navigation.astro';
+import Header from '../components/Header.astro';
+import Footer from '../components/Footer.astro';
+---
+
+<Layout title="Services | No Clocks">
+  <Navigation activeLink="/services" />
+  <Header />
+  <main class="site-main">
+    <section class="container">
+      <h2>Our Services</h2>
+      <p>Information about our services will be available soon. Stay tuned!</p>
+    </section>
+  </main>
+  <Footer />
+</Layout>


### PR DESCRIPTION
## Summary
- fill in placeholder contact page using Layout, Navigation and Footer
- fill in placeholder services page using Layout, Navigation and Footer

## Testing
- `npm run build`
